### PR TITLE
[feature/ITSPLAN-25] 화이트 테마인 경우 구글 로그인 버튼과 구분이 안되는 현상

### DIFF
--- a/src/assets/styles/custom-btn.css
+++ b/src/assets/styles/custom-btn.css
@@ -33,7 +33,7 @@
 .btn-google {
   @apply btn;
   background-color: #ffffff !important;
-  border-color: #ffffff !important;
+  border-color: #dee2e6 !important;
   box-shadow: 0 0 5px rgb(0, 0, 0, 30%);
   color: #000000 !important;
   text-transform: none;


### PR DESCRIPTION
- 연한 회색으로 구분되게 하기 (velog 참고)